### PR TITLE
Move back to armhf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/openjdk@sha256:3851dc826fe13a9dfa7561a94dfb5de415a2b8932a17ab16a35f1684591579c0
+FROM arm32v7/openjdk:8-jre-slim
 HEALTHCHECK CMD curl --fail http://127.0.0.1:8088 || exit 1
 
 ARG OMADA_FILENAME=Omada_Controller_v3.0.5_linux_x64
@@ -13,15 +13,15 @@ RUN apt-get update && \
     wget && \
   rm -rf /var/lib/apt/lists/*
 
-RUN wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u10_armel.deb && \
-  dpkg -i libssl1.0.0_1.0.1t-1+deb8u10_armel.deb
+RUN wget -q http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u10_armhf.deb && \
+  dpkg -i libssl1.0.0_1.0.1t-1+deb8u10_armhf.deb
 
-RUN wget https://static.tp-link.com/2018/201811/20181108/$OMADA_FILENAME.tar.gz.zip && \
+RUN wget -q https://static.tp-link.com/2018/201811/20181108/$OMADA_FILENAME.tar.gz.zip && \
   unzip $OMADA_FILENAME.tar.gz.zip
 
 RUN tar -xvf $OMADA_FILENAME.tar.gz
 
-RUN wget https://andyfelong.com/downloads/$MONGO_ARM_FILENAME.tar.gz && \
+RUN wget -q https://andyfelong.com/downloads/$MONGO_ARM_FILENAME.tar.gz && \
   tar -xvf $MONGO_ARM_FILENAME.tar.gz && \
   cp mongod /tmp/$OMADA_FILENAME/bin/
 


### PR DESCRIPTION
- Move back to armhf builds now that openjdk images are built for armhf.
- Switch libssl package to the right architecture
- Make wget quiet.