### PR TITLE
3.2.1 working on Raspberry Pi 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm32v7/openjdk:8u181-jre-slim
 HEALTHCHECK CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
-
-ARG OMADA_FILENAME=Omada_Controller_v3.0.5_linux_x64
+#https://static.tp-link.com/2019/201907/20190726/Omada_Controller_v3.2.1_linux_x64.tar.gz
+ARG OMADA_FILENAME=Omada_Controller_v3.2.1_linux_x64
 ARG MONGO_ARM_FILENAME=core_mongodb_3_0_14
 
 COPY bin/qemu-arm-static /usr/bin
@@ -16,7 +16,7 @@ RUN apt-get update && \
 RUN wget -q http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u11_armhf.deb && \
   dpkg -i libssl1.0.0_1.0.1t-1+deb8u11_armhf.deb
 
-RUN wget -q https://static.tp-link.com/2018/201811/20181108/$OMADA_FILENAME.tar.gz.zip && \
+RUN wget -q https://static.tp-link.com/2019/201907/20190726/$OMADA_FILENAME.tar.gz.zip && \
   unzip $OMADA_FILENAME.tar.gz.zip
 
 RUN tar -xvf $OMADA_FILENAME.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/openjdk:8u181-jre-slim
+FROM arm64v8/openjdk:8u181-jre-slim
 HEALTHCHECK CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 #https://static.tp-link.com/2019/201907/20190726/Omada_Controller_v3.2.1_linux_x64.tar.gz
 ARG OMADA_FILENAME=Omada_Controller_v3.2.1_linux_x64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/openjdk:8u181-jre-slim
+FROM arm32v7/openjdk:8u181-jre-slim
 HEALTHCHECK CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 #https://static.tp-link.com/2019/201907/20190726/Omada_Controller_v3.2.1_linux_x64.tar.gz
 ARG OMADA_FILENAME=Omada_Controller_v3.2.1_linux_x64

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,11 @@ RUN apt-get update && \
     wget && \
   rm -rf /var/lib/apt/lists/*
 
-RUN wget -q http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u11_armhf.deb && \
-  dpkg -i libssl1.0.0_1.0.1t-1+deb8u11_armhf.deb
+RUN wget -q http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb && \
+  dpkg -i libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb
 
-RUN wget -q https://static.tp-link.com/2019/201907/20190726/$OMADA_FILENAME.tar.gz.zip && \
-  unzip $OMADA_FILENAME.tar.gz.zip
-
-RUN tar -xvf $OMADA_FILENAME.tar.gz
+RUN wget -q https://static.tp-link.com/2019/201907/20190726/$OMADA_FILENAME.tar.gz && \
+  tar -xvf $OMADA_FILENAME.tar.gz --strip 1
 
 RUN wget -q https://andyfelong.com/downloads/$MONGO_ARM_FILENAME.tar.gz && \
   tar -xvf $MONGO_ARM_FILENAME.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm32v7/openjdk:8u212-jre-slim
-HEALTHCHECK CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
-#https://static.tp-link.com/2019/201907/20190726/Omada_Controller_v3.2.1_linux_x64.tar.gz
-ARG OMADA_FILENAME=Omada_Controller_v3.2.1_linux_x64
+HEALTHCHECK --start-period=15m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
+ARG OMADA_PATH=2020/202001/20200116/Omada_Controller_v3.2.6_linux_x64.tar.gz
+ARG OMADA_FILENAME=Omada_Controller_v3.2.6_linux_x64
 ARG MONGO_ARM_FILENAME=core_mongodb_3_0_14
 
 COPY bin/qemu-arm-static /usr/bin
@@ -16,8 +16,8 @@ RUN apt-get update && \
 RUN wget -q http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb && \
   dpkg -i libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb
 
-RUN wget -q https://static.tp-link.com/2019/201907/20190726/$OMADA_FILENAME.tar.gz && \
-  tar -xvf $OMADA_FILENAME.tar.gz --strip 1
+RUN wget -q https://static.tp-link.com/$OMADA_PATH && \
+  tar -xvf $OMADA_FILENAME.tar.gz
 
 RUN wget -q https://andyfelong.com/downloads/$MONGO_ARM_FILENAME.tar.gz && \
   tar -xvf $MONGO_ARM_FILENAME.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/openjdk:8u181-jre-slim
+FROM arm32v7/openjdk:8u212-jre-slim
 HEALTHCHECK CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 #https://static.tp-link.com/2019/201907/20190726/Omada_Controller_v3.2.1_linux_x64.tar.gz
 ARG OMADA_FILENAME=Omada_Controller_v3.2.1_linux_x64

--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,4 @@ if [ ! -f ./bin/qemu-arm-static ]; then
   docker run --rm --privileged multiarch/qemu-user-static:register --reset
 fi
 
-docker build $@
+docker build . -t frnby/omada-eap-controller:latest

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -d --net=host --restart=always -v omada_data:/opt/tplink/EAPController/data -v omada_logs:/opt/tplink/EAPController/logs --name omada-eap-controller frnby/omada-eap-controller:latest


### PR DESCRIPTION
I was experiencing instability with the container, so started tweaking it to see if I could improve it. This pull request incorporates another fork's changes, as well as:
- Bumps the OpenJDK version to 8u212 (this seemed to immediately fix the issues noted in #8 )
- Updates libels to 1.0.1t-1+deb8u12 (IIRC the previous version was no longer available)

The container based on this image has been running on my RPi now for 2 days without a restart.